### PR TITLE
Allow aws-signing-proxy to run in a shared-fate mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM scratch
+FROM alpine:3.7
 MAINTAINER uSwitch Cloud <cloud@uswitch.com>
 
 COPY bin/aws-signing-proxy-linux-amd64 /aws-signing-proxy
+COPY entrypoint.sh /entrypoint.sh
 
 EXPOSE 8080
 
-ENTRYPOINT ["/aws-signing-proxy"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+PROXY_BIN="/aws-signing-proxy"
+FATE=${FATE:-"standlone"}
+FATE_MOUNT=${FATE_MOUNT:-"/tmp/fate"}
+FATE_FILE=${FATE_FILE:-"${FATE_MOUNT}/main-terminated"}
+
+if [ "${FATE}" == "shared" ]; then
+    echo "Running in shared-fate mode"
+    echo "Proxy will terminate when ${FATE_FILE} is present"
+
+    ${PROXY_BIN} ${@} &
+    PROXY_PID=$!
+
+    while true; do
+        if [[ -f "${FATE_FILE}" ]]; then kill -SIGTERM ${PROXY_PID}; fi
+        sleep 2
+    done &
+
+    wait ${PROXY_PID}
+
+    if [[ -f "${FATE_FILE}" ]]; then exit 0; fi
+else
+    echo "Running in standalone mode"
+    exec ${PROXY_BIN} ${@}
+fi


### PR DESCRIPTION
To allow for using this proxy in Jobs we need to have a method of terminating it when the "main" container exits.

This wraps the proxy in some bash that will check for the existence of a configurable file.

If no config is provided it will just exec the proxy as usual.

Inspired by this: https://github.com/kubernetes/kubernetes/issues/25908#issuecomment-308569672